### PR TITLE
Made SMTP check RFC compatible

### DIFF
--- a/check_dane
+++ b/check_dane
@@ -130,7 +130,7 @@ def check_cert_expiry(cert, days_warning, days_critical=None):
 
     if days_critical:
         if date_diff <= datetime.timedelta(days_critical):
-             nagios_critical("{}:{} cert expires in {} days".format(args.host, args.port, date_diff.days))
+            nagios_critical("{}:{} cert expires in {} days".format(args.host, args.port, date_diff.days))
 
     if date_diff <= datetime.timedelta(days_warning):
         nagios_warning("{}:{} cert expires in {} days".format(args.host, args.port, date_diff.days))
@@ -318,4 +318,4 @@ def main():
 if __name__ == "__main__":
     main()
 
-# kate: space-indent on; indent-width 4; 
+# kate: space-indent on; indent-width 4;

--- a/check_dane
+++ b/check_dane
@@ -178,13 +178,13 @@ def smtp_read_response(sock):
 
 def connect_smtp(sock):
     smtp_read_response(sock)
-    sock.sendall(b"EHLO openssl.client.net\n")
+    sock.sendall(b"EHLO openssl.client.net\r\n")
 
     response = smtp_read_response(sock)
     if "STARTTLS" not in response:
         raise ProtocolError("Server doesn't support STARTTLS")
 
-    sock.sendall(b"STARTTLS\n")
+    sock.sendall(b"STARTTLS\r\n")
 
     smtp_read_response(sock)
 

--- a/check_dane
+++ b/check_dane
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (C) 2014-2016 Felix Geyer <debfx@fobos.de>
 #


### PR DESCRIPTION
I made the following changes:
- I've changed the shebang to use this check_also in a virtualenv
- I've improved indentation, removed some trailing whitespaces
- I've made the SMTP requests RFC compliant:  
  To send SMTP commands we have to use \r\n according to the RFC, so I changed this.
