### PR TITLE
Show hostname:port on TLS connection errors

### DIFF
--- a/check_dane
+++ b/check_dane
@@ -167,7 +167,8 @@ def connect_to_host(connect_host, connect_port, args, check_cert):
     try:
         return context.wrap_socket(sock, server_hostname=args.host)
     except (ProtocolError, ssl.SSLError) as e:
-        nagios_unknown("Can't establish a TLS connection\n" + str(e))
+        nagios_unknown("Can't establish a TLS connection to %s:%s: %s" %
+                (connect_host, connect_port, str(e)))
 
 def smtp_read_response(sock):
     response = ""


### PR DESCRIPTION
Thanks for check_dane!

This pull requests improves error reporting a bit. Ideally we could also show the IP address used, but it didn't seem to be available in this context.

(Fwiw, I had other errors and tracebacks during my tests as well, but didn't go into debugging because the setup Just Worked eventually. Still, this patch should improve things a bit.)
