### PR TITLE
Updated resolver to use resolve instead of query for dnspython 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Requirements
 ============
 
    * Python >= 3.4
-   * [dnspython](http://www.dnspython.org/)
+   * [dnspython](http://www.dnspython.org/) >= 2.0
    * openssl binary
    * DNSSEC capable resolver (or use --no-dnssec but be aware of the security implications)
 

--- a/check_dane
+++ b/check_dane
@@ -98,7 +98,7 @@ def get_tlsa_records(args: argparse.Namespace) -> dns.resolver.Answer:
     tlsa_domain = "_{}._tcp.{}".format(args.port, args.host)
 
     try:
-        tlsa_records = resolver.query(tlsa_domain, dns.rdatatype.TLSA)
+        tlsa_records = resolver.resolve(tlsa_domain, dns.rdatatype.TLSA)
     except dns.resolver.NXDOMAIN:
         nagios_critical("No DNS TLSA record found: {}".format(tlsa_domain))
     except dns.exception.Timeout:


### PR DESCRIPTION
Moin!

dnspython version 2.0.0 which is the default now for python3 uses resolve instead of query as the default method for a resolver to ask a resolving query. Update the code and README.md to reflect that.

So long
-Ralf
